### PR TITLE
:sparkles: カード移動アニメーションの追加

### DIFF
--- a/CHANGELOG_CLAUDE.md
+++ b/CHANGELOG_CLAUDE.md
@@ -2,6 +2,15 @@
 
 Claude Code で行った変更の履歴を新しいものから順に記録する。
 
+## 2026-05-31 アニメーション実装のレビュー指摘対応
+
+- 概要: PR #13 のセルフレビュー指摘を反映。`drawSource`（引いたカードの起点）の管理を `Game` インスタンス側へ移し、操作と状態を原子的に同期。z-index の重複指定を整理。
+- 変更ファイル:
+  - src/script/game.js — `drawSource` を Game の状態として保持。`throwAndDrawDeck`/`throwAndDrawDiscard` 内で起点を設定（プロップ伝播タイミング依存を解消）
+  - src/pages/PlayGame.vue — `drawSource` の data・個別バインドを削除し `props()` 経由で `game.drawSource` を渡すよう変更
+  - src/components/molecules/HandsShowed.vue — `.card-leave-active` の z-index 重複指定を削除（JS フック側で担保）
+- 理由: 引いたカードの起点が稀にズレる懸念を構造的に解消し、状態管理の一貫性と可読性を高めるため。
+
 ## 2026-05-31 カード移動アニメーションの追加
 
 - 概要: 手札の選択・捨て・引きの動きが即時反映で見えづらかったため、カードの移動・並び替え・選択のアニメーションを追加した。あわせて `npm install` のハング（キャッシュ破損）を修復。

--- a/CHANGELOG_CLAUDE.md
+++ b/CHANGELOG_CLAUDE.md
@@ -1,0 +1,16 @@
+# Claude 変更履歴
+
+Claude Code で行った変更の履歴を新しいものから順に記録する。
+
+## 2026-05-31 カード移動アニメーションの追加
+
+- 概要: 手札の選択・捨て・引きの動きが即時反映で見えづらかったため、カードの移動・並び替え・選択のアニメーションを追加した。あわせて `npm install` のハング（キャッシュ破損）を修復。
+- 変更ファイル:
+  - src/utils/animation/cardFly.js — 新規。`getBoundingClientRect` を用いた飛ぶアニメ（`flyEnter`/`flyLeave`）
+  - src/components/molecules/HandsShowed.vue — 手札を `transition-group` 化。捨て札へ飛ぶ/山札・捨て札から飛んでくる演出＋並び替えスライド＋選択浮き
+  - src/components/molecules/HandsHidden.vue — 相手手札を `transition-group` 化（180度回転のためCSSフェード+スライド方式）
+  - src/components/molecules/Deck.vue — 山札 `.deck-pile`／捨て札 `.discard-pile` クラス付与（座標取得用）
+  - src/components/organisms/BoardSurface.vue — `drawSource` プロップの配線
+  - src/pages/PlayGame.vue — `drawSource` 設定（山札/捨て札クリックで起点切替）＋新ゲーム時の再マウント `gameKey`
+  - src/script/game.js — 相手ターンの捨て→引きが見えるよう 0.5 秒の間を追加
+- 理由: カードの動きを視覚化し、自分と相手の手の動きを追えるようにするため。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# プロジェクト設定（seven）
+
+Vue 2 + Vuetify 2 製のトランプゲーム「seven」。
+
+## YOU MUST
+
+- **Claude でコードを変更した場合、コミット前に必ず `CHANGELOG_CLAUDE.md` の先頭へエントリを追記する。**
+  - 記載項目: 日付（`date "+%Y-%m-%d"` で取得）・要約タイトル・概要・変更ファイル一覧・理由
+  - フォーマットは `CHANGELOG_CLAUDE.md` 既存エントリに合わせる（新しいものを上に）
+- 回答は日本語で行う
+- 一度に全てを変更せず、小さな変更を積み重ね段階的に進める
+- 変更後はまとめて `npm run lint` を実行しエラーがないことを確認する
+
+## メモ
+
+- `docs/` は GitHub Pages 配信用のビルド成果物。手動編集せず `npm run build` で生成する
+- `npm install` がハングする場合は `npm cache clean --force` 後に `npm install --no-audit --no-fund`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "seven",
-  "version": "0.1.0",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seven",
-      "version": "0.1.0",
+      "version": "1.3.2",
       "dependencies": {
         "@mdi/font": "^7.3.67",
         "core-js": "^3.8.3",

--- a/src/components/molecules/Deck.vue
+++ b/src/components/molecules/Deck.vue
@@ -1,11 +1,11 @@
 <template>
   <v-card flat class="field" :disabled="isDisabled" color="rgba(0,0,0,0)">
     <v-row class="hands">
-      <v-col cols="6" class="relative">
+      <v-col cols="6" class="relative deck-pile">
         <CardBack  @onClick="onClickDeck"/>
         <v-chip @click="onClickDeck" class="absolute" >{{ deckSheets }}</v-chip>
       </v-col>
-      <v-col cols="6" class="relative">
+      <v-col cols="6" class="relative discard-pile">
         <Card :mark="discard" @onClick="onClickDiscard" />
       </v-col>
     </v-row>

--- a/src/components/molecules/HandsHidden.vue
+++ b/src/components/molecules/HandsHidden.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card flat class="field" color="rgba(0,0,0,0)">
-    <v-row class="hands">
+    <transition-group tag="div" name="card" class="row hands">
       <v-col
         cols="1"
         v-for="(card, i) in hands"
@@ -9,7 +9,7 @@
       >
         <CardBack />
       </v-col>
-    </v-row>
+    </transition-group>
   </v-card>
 </template>
 
@@ -44,6 +44,24 @@ export default {
 }
 .card-selected {
   transform: translateY(-24px);
+  transition: transform 0.15s ease-out;
+}
+// 並び替え（枚数変化）時の横スライド
+.card-move {
+  transition: transform 0.45s ease;
+}
+// 相手カードの出現/退場フェード（回転コンテナ内のため CSS で完結）
+.card-enter-active,
+.card-leave-active {
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+.card-enter,
+.card-leave-to {
+  opacity: 0;
+  transform: translateY(-24px) scale(0.8);
+}
+.card-leave-active {
+  position: absolute;
 }
 .field {
   padding: 12px;

--- a/src/components/molecules/HandsShowed.vue
+++ b/src/components/molecules/HandsShowed.vue
@@ -1,6 +1,12 @@
 <template>
   <v-card flat class="field" :disabled="isDisabled" color="rgba(0,0,0,0)">
-    <v-row class="hands">
+    <transition-group
+      tag="div"
+      name="card"
+      class="row hands"
+      @enter="onEnter"
+      @leave="onLeave"
+    >
       <v-col
         cols="1"
         v-for="(mark, i) in hands"
@@ -13,13 +19,14 @@
           @resetSelect="resetSelect"
         />
       </v-col>
-    </v-row>
+    </transition-group>
   </v-card>
 </template>
 
 <script>
 import Card from "@/components/common/Card.vue";
 import { marks } from "@/utils/mark/markUtil";
+import { flyEnter, flyLeave } from "@/utils/animation/cardFly";
 
 export default {
   components: { Card },
@@ -32,6 +39,11 @@ export default {
     isDisabled: {
       type: Boolean,
       default: false,
+    },
+    // 引いたカードがどこから来たか（"deck" / "discard"）。enter アニメの起点に使う
+    drawSource: {
+      type: String,
+      default: "deck",
     },
     hands: {
       type: Array,
@@ -66,6 +78,14 @@ export default {
     resetSelect() {
       this.selected = [];
     },
+    onEnter(el, done) {
+      const selector =
+        this.drawSource === "discard" ? ".discard-pile" : ".deck-pile";
+      flyEnter(el, done, selector);
+    },
+    onLeave(el, done) {
+      flyLeave(el, done, ".discard-pile");
+    },
   },
 };
 </script>
@@ -76,8 +96,15 @@ export default {
 }
 .card-selected {
   transform: translateY(-24px);
-  // ヌルっと動かせるけどカード移動のアニメーションが実装だるいから入れない
-  // transition: 0.1s all ease-out;
+  transition: transform 0.15s ease-out;
+}
+// 案B: 並び替え（枚数変化・ソート）時の横スライド
+.card-move {
+  transition: transform 0.45s ease;
+}
+.card-leave-active {
+  // JS フック(flyLeave)が position:fixed で制御するため z-index のみ確保
+  z-index: 10;
 }
 .field {
   padding-bottom: 12px;

--- a/src/components/molecules/HandsShowed.vue
+++ b/src/components/molecules/HandsShowed.vue
@@ -99,12 +99,9 @@ export default {
   transition: transform 0.15s ease-out;
 }
 // 案B: 並び替え（枚数変化・ソート）時の横スライド
+// 退場(leave)・出現(enter)は JS フック(flyLeave/flyEnter)が制御する
 .card-move {
   transition: transform 0.45s ease;
-}
-.card-leave-active {
-  // JS フック(flyLeave)が position:fixed で制御するため z-index のみ確保
-  z-index: 10;
 }
 .field {
   padding-bottom: 12px;

--- a/src/components/organisms/BoardSurface.vue
+++ b/src/components/organisms/BoardSurface.vue
@@ -29,6 +29,7 @@
         ref="handsShowed"
         :isDisabled="isDisabledHands"
         :hands="playerHands"
+        :drawSource="drawSource"
         @selectCard="selectCard"
       />
     </v-row>
@@ -81,6 +82,10 @@ export default {
     isDisabledHands: {
       type: Boolean,
       default: false,
+    },
+    drawSource: {
+      type: String,
+      default: "deck",
     },
   },
   methods: {

--- a/src/pages/PlayGame.vue
+++ b/src/pages/PlayGame.vue
@@ -28,7 +28,6 @@
       @onClickDeck="onClickDeck"
       @onClickDiscard="onClickDiscard"
       @selectCard="selectCard"
-      :drawSource="drawSource"
       :isDisabledDeck="isDisabledDeck"
       :isDisabledHands="phase != 'player'"
     />
@@ -175,8 +174,6 @@ export default {
     selectedCard: [],
     newGameDialog: true,
     gameResultDialog: false,
-    // 引いたカードの起点（enter アニメ用）。山札="deck" / 捨て札="discard"
-    drawSource: "deck",
     // 新ゲーム時に BoardSurface を再マウントし、配り直しのアニメ暴発を防ぐ
     gameKey: 0,
   }),
@@ -193,6 +190,8 @@ export default {
         hiddenSelected: this.game.enemySelect,
         deckSheets: this.game.deck.length,
         discard: this.game.discard[0],
+        // 引いたカードの起点（enter アニメ用）。Game 側で操作と同期して設定される
+        drawSource: this.game.drawSource,
       };
     },
     turn() {
@@ -208,14 +207,12 @@ export default {
   methods: {
     newGame(level) {
       this.game = new Game(level);
-      this.drawSource = "deck";
       this.gameKey += 1;
       this.newGameDialog = false;
       this.gameResultDialog = false;
     },
     async onClickDeck() {
       this.$refs.boardSurface.resetSelect();
-      this.drawSource = "deck";
       const result = await this.game.throwAndDrawDeck(this.selectedCard);
       this.selectedCard = [];
       if (typeof result == "string") {
@@ -226,7 +223,6 @@ export default {
     },
     async onClickDiscard() {
       this.$refs.boardSurface.resetSelect();
-      this.drawSource = "discard";
       const result = await this.game.throwAndDrawDiscard(this.selectedCard);
       this.selectedCard = [];
       if (typeof result == "string") {

--- a/src/pages/PlayGame.vue
+++ b/src/pages/PlayGame.vue
@@ -23,10 +23,12 @@
 
     <BoardSurface
       ref="boardSurface"
+      :key="gameKey"
       v-bind="props"
       @onClickDeck="onClickDeck"
       @onClickDiscard="onClickDiscard"
       @selectCard="selectCard"
+      :drawSource="drawSource"
       :isDisabledDeck="isDisabledDeck"
       :isDisabledHands="phase != 'player'"
     />
@@ -173,6 +175,10 @@ export default {
     selectedCard: [],
     newGameDialog: true,
     gameResultDialog: false,
+    // 引いたカードの起点（enter アニメ用）。山札="deck" / 捨て札="discard"
+    drawSource: "deck",
+    // 新ゲーム時に BoardSurface を再マウントし、配り直しのアニメ暴発を防ぐ
+    gameKey: 0,
   }),
   computed: {
     props() {
@@ -202,11 +208,14 @@ export default {
   methods: {
     newGame(level) {
       this.game = new Game(level);
+      this.drawSource = "deck";
+      this.gameKey += 1;
       this.newGameDialog = false;
       this.gameResultDialog = false;
     },
     async onClickDeck() {
       this.$refs.boardSurface.resetSelect();
+      this.drawSource = "deck";
       const result = await this.game.throwAndDrawDeck(this.selectedCard);
       this.selectedCard = [];
       if (typeof result == "string") {
@@ -217,6 +226,7 @@ export default {
     },
     async onClickDiscard() {
       this.$refs.boardSurface.resetSelect();
+      this.drawSource = "discard";
       const result = await this.game.throwAndDrawDiscard(this.selectedCard);
       this.selectedCard = [];
       if (typeof result == "string") {

--- a/src/script/game.js
+++ b/src/script/game.js
@@ -163,6 +163,8 @@ export const Game = class {
             this.enemyThrowAndDrawDeck(selected)
         }
         this.enemySelect = []
+        // 捨て→引きのアニメーションが見えるよう少し待つ
+        await waitSecond(0.5)
         if (this.checkResult(this.enemyHands)) {
             this.phase = "finished"
             return "相手の勝ち..."

--- a/src/script/game.js
+++ b/src/script/game.js
@@ -26,6 +26,8 @@ export const Game = class {
     }
     // 手札を捨ててデッキから引く
     async throwAndDrawDeck(throwCards) {
+        // 引いたカードの起点（enter アニメ用）
+        this.drawSource = "deck"
         // 捨てる
         this.discard = throwCards.concat(this.discard)
         this.playerHands = this.playerHands.filter((card) => !throwCards.includes(card))
@@ -44,6 +46,8 @@ export const Game = class {
     }
     // 手札を捨てて捨て札から引く
     async throwAndDrawDiscard(throwCards) {
+        // 引いたカードの起点（enter アニメ用）
+        this.drawSource = "discard"
         // 手札から抜く
         this.playerHands = this.playerHands.filter((card) => !throwCards.includes(card))
         // 手札に取り入れる
@@ -189,6 +193,8 @@ export const Game = class {
             this.discard = this.drawDeck(1)
         }
         this.turn = 1
+        // 引いたカードの起点（"deck" / "discard"）。enter アニメの起点に使う
+        this.drawSource = "deck"
         /*
         フェーズ
         プレーヤーのフェーズ："player"

--- a/src/utils/animation/cardFly.js
+++ b/src/utils/animation/cardFly.js
@@ -1,0 +1,77 @@
+// カードの「飛ぶ」アニメーション用ユーティリティ
+// transition-group の JS フック（@enter / @leave）から呼び出す。
+// getBoundingClientRect でソース/ターゲットの位置を取得し、FLIP 技法で移動させる。
+
+const DURATION = 450; // ms。CSS の .card-move と揃える
+
+// transitionend もしくはフォールバックのタイマーで一度だけ done() を呼ぶ
+function once(el, done) {
+  let called = false;
+  const finish = () => {
+    if (called) return;
+    called = true;
+    el.removeEventListener("transitionend", finish);
+    clearTimeout(timer);
+    done();
+  };
+  const timer = setTimeout(finish, DURATION + 80);
+  el.addEventListener("transitionend", finish);
+}
+
+// 引いたカードが sourceSelector（山札/捨て札）の位置から自分のスロットへ飛んでくる
+export function flyEnter(el, done, sourceSelector) {
+  const src = document.querySelector(sourceSelector);
+  if (!src) {
+    done();
+    return;
+  }
+  const elRect = el.getBoundingClientRect();
+  const srcRect = src.getBoundingClientRect();
+  const dx = srcRect.left - elRect.left;
+  const dy = srcRect.top - elRect.top;
+
+  el.style.transition = "none";
+  el.style.transform = `translate(${dx}px, ${dy}px) scale(0.8)`;
+  el.style.opacity = "0";
+  // リフロー強制でスタート位置を確定
+  void el.offsetWidth;
+
+  el.style.transition = `transform ${DURATION}ms ease, opacity ${DURATION}ms ease`;
+  el.style.transform = "none";
+  el.style.opacity = "1";
+
+  once(el, () => {
+    el.style.transition = "";
+    el.style.transform = "";
+    el.style.opacity = "";
+    done();
+  });
+}
+
+// 捨てたカードが自分のスロットから targetSelector（捨て札）へ飛んでいく
+export function flyLeave(el, done, targetSelector) {
+  const elRect = el.getBoundingClientRect();
+  // 流れから外して残りのカードを詰めさせる（fixed で viewport 座標に固定）
+  el.style.position = "fixed";
+  el.style.left = `${elRect.left}px`;
+  el.style.top = `${elRect.top}px`;
+  el.style.width = `${elRect.width}px`;
+  el.style.margin = "0";
+  el.style.zIndex = "10";
+
+  const tgt = document.querySelector(targetSelector);
+  if (!tgt) {
+    done();
+    return;
+  }
+  const tgtRect = tgt.getBoundingClientRect();
+  const dx = tgtRect.left - elRect.left;
+  const dy = tgtRect.top - elRect.top;
+  void el.offsetWidth;
+
+  el.style.transition = `transform ${DURATION}ms ease, opacity ${DURATION}ms ease`;
+  el.style.transform = `translate(${dx}px, ${dy}px) scale(0.8)`;
+  el.style.opacity = "0";
+
+  once(el, done);
+}


### PR DESCRIPTION
## 概要
手札の選択・捨て・引きの動きが即時反映で見えづらかったため、カードの移動・並び替え・選択のアニメーションを追加しました。追加ライブラリなし（Vue 2 標準の `transition-group` + FLIP技法）。

## 変更内容
- **移動演出**: 捨てたカードが捨て札へ飛ぶ／引いたカードが山札・捨て札から手札へ飛んでくる（`src/utils/animation/cardFly.js` 新規）
- **並び替え（案B）**: 枚数変化・ソート時に手札が横スライド
- **選択（案A）**: 選択カードが滑らかに浮き上がる
- **相手手札**: 180度回転コンテナのためCSSフェード+スライド方式
- 相手ターンに捨て→引きが見えるよう0.5秒の間を追加（`game.js`）
- 新ゲーム時の配り直しでアニメが暴発しないよう `gameKey` で再マウント

## その他
- `npm install` のハング（npmキャッシュ破損）を修復
- Claude変更履歴ルールを整備（`CHANGELOG_CLAUDE.md` / `CLAUDE.md`）

## 検証
- `npm run lint` … エラーなし
- `npm run build` … Build complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)